### PR TITLE
Set process title to indicate whether it's a master or a worker

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -136,6 +136,11 @@ var Master = module.exports = function Master(server) {
     sock.setEncoding('ascii');
     sock.on('data', self.frame.bind(self));
   });
+
+  if (this.isMaster)
+    process.title = "node/cluster master"
+  else
+    process.title = "node/cluster worker:" + process.env.CLUSTER_WORKER
 };
 
 /**


### PR DESCRIPTION
I'd like to know which process is the master and which are the workers. This tiny commits sets process.title in the Master constructor to change the process name as it appears in ps.
