### PR TITLE
Add support in reload() for customizing watched file extensions.

### DIFF
--- a/docs/reload.md
+++ b/docs/reload.md
@@ -37,3 +37,11 @@
        cluster(server)
         .use(cluster.reload('lib', { signal: 'SIGQUIT' }))
         .listen(3000);
+
+ By default the plugin watches only for changes in files with a `.js` file extension. This can be changed by modifying the `watchedFileExtensions` array before instantiating the plugin. The following reloads when `.js` and `.coffee` files change.
+
+       cluster.reload.watchedFileExtensions.push('.coffee');
+
+       cluster(server)
+        .use(cluster.reload())
+        .listen(3000);

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -1,4 +1,3 @@
-
 /*!
  * Cluster - reload
  * Copyright (c) 2011 LearnBoost <dev@learnboost.com>
@@ -98,7 +97,7 @@ exports = module.exports = function(files, options){
 
     // watch file for changes
     function watch(file) {
-      if (!~exports.watchFileExtensions.indexOf(extname(file))) return;
+      if (!~exports.watchedFileExtensions.indexOf(extname(file))) return;
       fs.watchFile(file, { interval: interval }, function(curr, prev){
         if (restarting) return;
         if (curr.mtime > prev.mtime) {

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -10,7 +10,9 @@
  */
 
 var fs = require('fs')
-  , basename = require('path').basename;
+  , path = require('path')
+  , basename = path.basename
+  , extname = path.extname;
 
 /**
  * Restart the server the given js `files` have changed.
@@ -96,8 +98,7 @@ exports = module.exports = function(files, options){
 
     // watch file for changes
     function watch(file) {
-      // js-only for now
-      if (!~file.indexOf('.js')) return;
+      if (!~exports.watchFileExtensions.indexOf(extname(file))) return;
       fs.watchFile(file, { interval: interval }, function(curr, prev){
         if (restarting) return;
         if (curr.mtime > prev.mtime) {
@@ -118,3 +119,9 @@ exports = module.exports = function(files, options){
  */
 
 exports.ignoreDirectories = ['node_modules', 'support', 'test', 'bin'];
+
+/**
+ * File extensions to watch.
+ */
+
+exports.watchedFileExtensions = ['.js'];


### PR DESCRIPTION
Here is a small patch that adds support to change which file extensions the reload plugin watches for.

Something like this:

```
cluster.reload.watchedFileExtensions.push('.less');

cluster(app)
 .reload()
 .listen(3000);
```
