### PR TITLE
Eliminating some false positives on the Reload plugin

### DIFF
--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -97,7 +97,7 @@ exports = module.exports = function(files, options){
     // watch file for changes
     function watch(file) {
       // js-only for now
-      if (!~file.indexOf('.js')) return;
+      if (file.substr(-3,3) !== '.js') return;
       fs.watchFile(file, { interval: interval }, function(curr, prev){
         if (restarting) return;
         if (curr.mtime > prev.mtime) {


### PR DESCRIPTION
Vim likes to throw .myfile.js.swp files in the same directory as myfile.js.  This has the nasty side-effect of forcing Cluster to restart every few keystrokes.  This patch just changes the reload filter to only trigger on files with an extension of .js, instead of files that happen to have .js somewhere in the name.
