### PR TITLE
Typo in pidfiles documentation

### DIFF
--- a/docs/pidfiles.md
+++ b/docs/pidfiles.md
@@ -22,7 +22,7 @@ save to `./pids`:
 save to `/var/run/node`:
 
      cluster(server)
-       .use(cluster.logger('/var/run/node'))
+       .use(cluster.pidfiles('/var/run/node'))
        .listen(3000);
 
 ### master.pidfiles


### PR DESCRIPTION
A small correction: The [pidfiles page](http://learnboost.github.com/cluster/docs/pidfiles.html) gives the example

```
.use(cluster.logger('/var/run/node'))
```

when I'm fairly certain it should say

```
.use(cluster.pidfiles('/var/run/node'))
```
