### PR TITLE
Add support in reload() for customizing watched file extensions. Revision 2.

### DIFF
--- a/docs/reload.md
+++ b/docs/reload.md
@@ -1,4 +1,3 @@
-
 ## Reload
 
   Restart the server the given js `files` have changed.
@@ -37,3 +36,9 @@
        cluster(server)
         .use(cluster.reload('lib', { signal: 'SIGQUIT' }))
         .listen(3000);
+
+ Watching coffee-script files as well.
+
+       cluster(server)
+         .use(cluster.reload('lib', { extensions: ['.js', '.coffee'] }))
+         .listen(3000);

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -1,4 +1,3 @@
-
 /*!
  * Cluster - reload
  * Copyright (c) 2011 LearnBoost <dev@learnboost.com>
@@ -22,6 +21,7 @@ var fs = require('fs')
  *
  *   - `signal` Signal to send, defaults to __SIGTERM__
  *   - `interval` Watcher interval, defaulting to `100`
+ *   - `extensions` File extensions to watch, defaults to ['.js']
  *
  * Examples:
  *
@@ -39,6 +39,10 @@ var fs = require('fs')
  *
  *     cluster(server)
  *       .use(cluster.reload('lib', { signal: 'SIGQUIT', interval: 60000 }))
+ *       .listen(3000);
+ *
+ *     cluster(server)
+ *       .use(cluster.reload('lib', { extensions: ['.js', '.coffee'] }))
  *       .listen(3000);
  *
  * Ignore Directories:
@@ -66,7 +70,8 @@ exports = module.exports = function(files, options){
 
   // defaults
   var sig = options.sig || 'SIGTERM'
-    , interval = options.interval || 100;
+    , interval = options.interval || 100
+    , extensions = options.extensions || ['.js'];
 
   return function(master){
     var restarting;
@@ -97,8 +102,7 @@ exports = module.exports = function(files, options){
 
     // watch file for changes
     function watch(file) {
-      // js-only for now
-      if (extname(file) != '.js') return;
+      if (!~extensions.indexOf(extname(file)) return;
       fs.watchFile(file, { interval: interval }, function(curr, prev){
         if (restarting) return;
         if (curr.mtime > prev.mtime) {

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -102,7 +102,7 @@ exports = module.exports = function(files, options){
 
     // watch file for changes
     function watch(file) {
-      if (!~extensions.indexOf(extname(file)) return;
+      if (!~extensions.indexOf(extname(file))) return;
       fs.watchFile(file, { interval: interval }, function(curr, prev){
         if (restarting) return;
         if (curr.mtime > prev.mtime) {


### PR DESCRIPTION
Here is an implementation of the other syntax.

```
 cluster(server)
   .use(cluster.reload('lib', { extensions: ['.js', '.coffee'] }))
   .listen(3000);
```
