### PR TITLE
Better Master / cli() error handling

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -793,8 +793,14 @@ Master.prototype.startListening = function(bind){
   // bind / listen
   function listen() {
     if (bind) {
-      binding.bind(self.fd, self.port, self.host);
-      binding.listen(self.fd, self.options.backlog);
+      try {
+        binding.bind(self.fd, self.port, self.host);
+        binding.listen(self.fd, self.options.backlog);
+      } catch(e) {
+        // make sure we kill workers
+        self.remove(self.children.length);
+        throw e;
+      }
     }
     self.callback && self.callback();
     self.emit('listening');

--- a/lib/plugins/cli.js
+++ b/lib/plugins/cli.js
@@ -158,7 +158,7 @@ define('-s, --status, status', function(master){
  */
 
 define('-r, --restart, restart', function(master){
-  process.kill(master.pidof('master'), 'SIGUSR2');
+  tryKill(master.pidof('master'), 'SIGUSR2');
 }, 'Restart master by sending the SIGUSR2 signal');
 
 /**
@@ -166,7 +166,7 @@ define('-r, --restart, restart', function(master){
  */
 
 define('-g, --shutdown, shutdown', function(master){
-  process.kill(master.pidof('master'), 'SIGQUIT');
+  tryKill(master.pidof('master'), 'SIGQUIT');
 }, 'Graceful shutdown by sending the SIGQUIT signal');
 
 /**
@@ -174,7 +174,7 @@ define('-g, --shutdown, shutdown', function(master){
  */
 
 define('-S, --stop, stop', function(master){
-  process.kill(master.pidof('master'), 'SIGTERM');
+  tryKill(master.pidof('master'), 'SIGTERM');
 }, 'Hard shutdown by sending the SIGTERM signal');
 
 /**
@@ -200,6 +200,28 @@ define('-h, --help, help', function(master){
 define('-v, --version', function(master){
   console.log(require('../cluster').version);
 }, 'Output cluster version');
+
+/**
+ * Try to kill process, catch error if no process found
+ *
+ * @param {Number} pid
+ * @param {Number} sig
+ * @api private
+ */
+
+function tryKill(pid, sig) {
+  try {
+    process.kill(pid, sig);
+  } catch (err) {
+    if (ESRCH == err.errno) {
+      console.log();
+      console.log('Cluster isn\'t running');
+      console.log();
+    } else {
+      throw err;
+    }
+  }
+}
 
 /**
  * Require `pidfiles()` plugin.

--- a/lib/plugins/pidfiles.js
+++ b/lib/plugins/pidfiles.js
@@ -42,11 +42,18 @@ module.exports = function(dir){
     function fn(err){ if (err) throw err; }
 
     // augment master
-    // augment master
     master.pidof = function(name){
       var dir = master.pidfiles
-        , path = dir + '/' + name + '.pid'
-        , pid = fs.readFileSync(path, 'ascii');
+        , path = dir + '/' + name + '.pid';
+        
+      try{
+        var pid = fs.readFileSync(path, 'ascii');
+      } catch(e) {
+        console.error('');
+        console.error('Can\'t find master pid file. Cluster probably isn\'t running.');
+        console.error('');
+        process.exit(1);
+      }
       return parseInt(pid, 10);
     };
 


### PR DESCRIPTION
I saw you had a closed issue about cli(), but there still seemed to be some loopholes. The first commit adds some simple try/catch blocks to better handle running cli() commands when no master pid or process exists, the second one prevents zombie processes from sticking around after errors thrown on listen() (port in use, etc).

I didn't have time to write tests, but its simple enough that there shouldn't be any problems... works great for me.
