### PR TITLE
make it possible to pass {color: false} to debug()

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -25,3 +25,7 @@ Outputs verbose debugging information to _stderr_.
      cluster(server)
        .use(cluster.debug())
        .listen(3000);
+
+### Options
+
+  - `color`  enable color output, defaults to true

--- a/lib/plugins/debug.js
+++ b/lib/plugins/debug.js
@@ -6,32 +6,40 @@
  */
 
 /**
- * Logger.
- */
-
-var log = {
-  debug: function(str){
-    console.error('  \033[90mdebug - %s\033[0m', str);
-  },
-  info: function(str){
-    console.error('  info \033[90m- %s\033[0m', str);
-  },
-  warning: function(str){
-    console.error('  \033[33mwarning\033[0m \033[90m- %s\033[0m', str);
-  },
-  error: function(str){
-    console.error('  \033[31merror\033[0m \033[90m- %s\033[0m', str);
-  }
-};
-
-/**
  * Enable verbose debugging output.
  *
  * @return {Function}
  * @api public
  */
 
-module.exports = function(){
+module.exports = function(options){
+  options = options || {};
+
+  function color(text) {
+    if (options.color === false) {
+      return text.replace(/\033\[\d+m/g, '')
+    }
+    return text
+  }
+
+  /**
+   * Logger.
+   */
+  var log = {
+    debug: function(str){
+      console.error(color('  \033[90mdebug - %s\033[0m'), str);
+    },
+    info: function(str){
+      console.error(color('  info \033[90m- %s\033[0m'), str);
+    },
+    warning: function(str){
+      console.error(color('  \033[33mwarning\033[0m \033[90m- %s\033[0m'), str);
+    },
+    error: function(str){
+      console.error(color('  \033[31merror\033[0m \033[90m- %s\033[0m'), str);
+    }
+  };
+
   return function(master){
 
     // start


### PR DESCRIPTION
Sometimes it is nice to turn on debug() when logging cluster's stdout. This makes it possible to disable the color output so that it is easier to read in log files. Usage: `debug({color: false})`.
