### PR TITLE
Support Worker Initialization Functions

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -141,7 +141,7 @@ Worker.prototype.connect = function(id, options){
 
   var init;
   if (this.server && init_name && this.server[init_name] && (typeof this.server[init_name] == "function")) {
-    init = this.server[init_name];
+    init = this.server[init_name].bind(this);
   }
 
   if (init) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -124,6 +124,8 @@ Worker.prototype.start = function(){
  */
 
 Worker.prototype.connect = function(id, options){
+  var self = this;
+
   this.options = options;
 
   // worker id
@@ -134,6 +136,25 @@ Worker.prototype.connect = function(id, options){
 
   // title
   process.title = options['worker title'].replace('{n}', id);
+
+  var init_name = options['worker init'];
+
+  var init;
+  if (this.server && init_name && this.server[init_name] && (typeof this.server[init_name] == "function")) {
+    init = this.server[init_name];
+  }
+
+  if (init) {
+    init(function(err) {
+      if (err) {
+        console.error('error initializing worker '+id+': '+err);
+        self.close();
+      } else {
+        self.master.call('connect');
+      }
+    });
+    return;
+  }
 
   // notify master of connection
   this.master.call('connect');


### PR DESCRIPTION
Some workers may require an initialization sequence before they should
connect to the socket.

In order to utilize this, simply add:
  .set('worker init', 'method name')
to your cluster instance.

'method name' must be a method of the server that takes one callback
argument as follows:

function server.worker_init(callback) {
  <initialization code goes here>
  if (error) {
    return callback(&lt;error&gt;)
  }
  // no error
  return callback(null);
}

When running the callback, one argument should be supplied. If the
<error> is "truthy", then the worker will consider it to have failed. If
it is "falsy", then the worker will connect to the master.

Signed-off-by: Joshua Rubin joshua@rubixconsulting.com
