### PR TITLE
Allow calling all master methods from worker

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -69,7 +69,10 @@ Worker.prototype.start = function(){
   // proxy to provide worker id
   this.master.call = function(){
     var args = utils.toArray(arguments);
-    args.unshift(self.id);
+    // Allow calling master methods that don't take worker as first argument
+    if (args[0] !== false) {
+      args.unshift(self.id);
+    }
     return call.apply(this, args);
   };
 


### PR DESCRIPTION
Problem: Certain master methods like spawn() were previously
not possible to call from the worker, because they do not
accept a `worker` parameter as the first argument.

This patch allows calling a master method without providing a
worker id like so:

master.call(false, 'spawn', 1);

Fixes #123

(Ran all tests - they are passing)
