### PR TITLE
Make worker accessible to plugins

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -260,6 +260,7 @@ Master.prototype.start = function(fn){
     if (this.isWorker) {
       // connect the worker
       var worker = new Worker(this);
+      this.worker = worker;
       this.sock = net.createConnection(this.socketPath);
       this.sock.on('connect', function(){
         worker.start();


### PR DESCRIPTION
Problem: There was previously no way to get a hold of the Worker
instance inside a worker when writing a plugin. This patch
provides such a reference by attaching the Worker instance to the
Master instance inside a worker.

PS: I need this to manipulate the timeout of an individual worker from within the worker itself.
