### PR TITLE
Make worker accessible to plugins

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -290,6 +290,7 @@ Master.prototype.start = function(fn){
 
 Master.prototype.startWorker = function(){
   var worker = new Worker(this);
+  this.worker = worker;
   var sock = this.sock = dgram.createSocket('unix_dgram');
   sock.on('listening', worker.start.bind(worker));
   sock.bind(this.clientSocketPath);


### PR DESCRIPTION
Problem: There was previously no way to get a hold of the Worker
instance inside a worker when writing a plugin. This patch
provides such a reference by attaching the Worker instance to the
Master instance inside a worker.

(Rebased version of #127.)
