### PR TITLE
Allow reload plugin to continue restarting master after syntax errors are fixed.

### DIFF
--- a/examples/reload.js
+++ b/examples/reload.js
@@ -8,7 +8,7 @@ var cluster = require('../')
 
 // try loading, and changing "Hello", to "Hello World"
 
-var body = 'Hello, world!'
+var body = 'Hello'
   , len = body.length;
 var server = http.createServer(function(req, res){
   res.writeHead(200, { 'Content-Length': len });

--- a/examples/reload.js
+++ b/examples/reload.js
@@ -8,7 +8,7 @@ var cluster = require('../')
 
 // try loading, and changing "Hello", to "Hello World"
 
-var body = 'Hello'
+var body = 'Hello, world!'
   , len = body.length;
 var server = http.createServer(function(req, res){
   res.writeHead(200, { 'Content-Length': len });

--- a/lib/master.js
+++ b/lib/master.js
@@ -67,6 +67,7 @@ var node = process.execPath;
  *      which can be patched in order to preserve plugin state.
  *   - `restart`. Restart complete, new master established, previous died.
  *      Receives an object with state preserved by the `restarting` event.
+ *   - `exit`. When a restarted master process exits.
  *                
  * Signals:
  *
@@ -683,6 +684,12 @@ Master.prototype.spawnMaster = function(){
   var proc = spawn(node, this.cmd, {
       customFds: customFds
     , env: env
+  });
+
+  // watch for exit in case of problem during restart
+  var self = this;
+  proc.on('exit',function(){
+    self.emit('exit',{});
   });
   
   // unix domain socket for ICP + fd passing

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -115,6 +115,11 @@ exports = module.exports = function(files, options){
     master.on('restarting', function(){
       restarting = true;
     });
+
+    master.on('exit', function(){
+      // must have been a problem
+      restarting = false;
+    });
   }
 };
 


### PR DESCRIPTION
The reload plugin gets stuck if there's a syntax error. The master can't re-spawn since there's a syntax error, and the reload plugin won't try again, because the restarting flag gets set to true. This fork watches for the master process to exit and then emits an 'exit' event for the master. This way, the reload plugin can watch for the 'exit' event and reset its restarting flag.
