### PR TITLE
Handling directory read errors gracefully

### DIFF
--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -89,9 +89,13 @@ exports = module.exports = function(files, options){
           if (stat.isDirectory()) {
             if (~exports.ignoreDirectories.indexOf(basename(file))) return;
             fs.readdir(file, function(err, files){
-              files.map(function(f){
-                return file + '/' + f;
-              }).forEach(traverse);
+              if (!err) {
+                files.map(function(f){
+                  return file + '/' + f;
+                }).forEach(traverse);
+              } else {
+                console.error('Warning: failed reading directory ' + file, err.message);
+              }
             });
           } else {
             watch(file);

--- a/lib/plugins/reload.js
+++ b/lib/plugins/reload.js
@@ -10,7 +10,8 @@
 
 var fs = require('fs')
   , basename = require('path').basename
-  , extname = require('path').extname;
+  , extname = require('path').extname
+  , dirname = require('path').dirname;
 
 /**
  * Restart the server the given js `files` have changed.
@@ -94,7 +95,25 @@ exports = module.exports = function(files, options){
                   return file + '/' + f;
                 }).forEach(traverse);
               } else {
-                console.error('Warning: failed reading directory ' + file, err.message);
+                if (err.errno === 2) {
+                  fs.readlink(file, function(err, resolvedLink) {
+                    if (!err) {
+                      fs.readdir(dirname(file) + '/' + resolvedLink, function(err, files){
+                        if(!err) {
+                          files.map(function(f){
+                            return file + '/' + f;
+                          }).forEach(traverse);
+                        } else {
+                          console.error('Error reading directory ' + dirname(file) + '/' + resolvedLink, err.message);
+                        }
+                      });
+                    } else {
+                      console.log('error reading directory ' + file, err.message);
+                    }
+                  });
+                } else {
+                  console.log('error reading directory ' + file, err.message);
+                }
               }
             });
           } else {
@@ -119,7 +138,7 @@ exports = module.exports = function(files, options){
     master.on('restarting', function(){
       restarting = true;
     });
-  }
+  };
 };
 
 /**


### PR DESCRIPTION
Hit an issue with the fs failing to read a dir, which prevented Cluster from starting up.  Just wrote a little statement that skips readdir on an error and spits it out to the console.
