### PR TITLE
Shell scripts cannot easily read the cluster cli status

### DIFF
--- a/lib/plugins/cli.js
+++ b/lib/plugins/cli.js
@@ -1,4 +1,3 @@
-
 /*!
  * Cluster - cli
  * Copyright (c) 2011 LearnBoost <dev@learnboost.com>
@@ -134,6 +133,9 @@ define('-s, --status, status', function(master){
     process.exit(1);
   }
 
+  var someDead = false;
+  var allDead = true;
+
   console.log();
 
   // only pids
@@ -151,10 +153,12 @@ define('-s, --status, status', function(master){
       process.kill(pid, 0);
       status = 'alive';
       color = '36';
+      allDead = false;
     } catch (err) {
       if ('ESRCH' == err.code) {
         color = '31';
         status = 'dead';
+        someDead = true;
       } else {
         throw err;
       }
@@ -167,6 +171,11 @@ define('-s, --status, status', function(master){
   });
 
   console.log();
+
+  if (someDead || allDead) {
+    process.exit(allDead ? 2 : 1);
+  }
+
 }, 'Output cluster status');
 
 /**


### PR DESCRIPTION
Status uses process.exit with code 1 if at least one process is dead and code 2 if all processes are dead.
This allows shell scripts to interact with the cluster cli status command.
