### PR TITLE
Added a process.exit() to each of the cli definitions

### DIFF
--- a/lib/plugins/cli.js
+++ b/lib/plugins/cli.js
@@ -167,6 +167,7 @@ define('-s, --status, status', function(master){
   });
 
   console.log();
+  process.exit(0);
 }, 'Output cluster status');
 
 /**
@@ -175,6 +176,7 @@ define('-s, --status, status', function(master){
 
 define('-r, --restart, restart', function(master){
   master.killall('SIGUSR2');
+  process.exit(0);
 }, 'Restart master by sending the SIGUSR2 signal');
 
 /**
@@ -183,6 +185,7 @@ define('-r, --restart, restart', function(master){
 
 define('-g, --shutdown, shutdown', function(master){
   master.killall('SIGQUIT');
+  process.exit(0);
 }, 'Graceful shutdown by sending the SIGQUIT signal');
 
 /**
@@ -191,6 +194,7 @@ define('-g, --shutdown, shutdown', function(master){
 
 define('-S, --stop, stop', function(master){
   master.killall('SIGTERM');
+  process.exit(0);
 }, 'Hard shutdown by sending the SIGTERM signal');
 
 /**
@@ -207,6 +211,7 @@ define('-h, --help, help', function(master){
       + '\n');
   });
   console.log();
+  process.exit(0);
 }, 'Show help information');
 
 /**
@@ -215,6 +220,7 @@ define('-h, --help, help', function(master){
 
 define('-v, --version', function(master){
   console.log(require('../cluster').version);
+  process.exit(0);
 }, 'Output cluster version');
 
 /**


### PR DESCRIPTION
The cli definitions should exit after running.  Added process.exit() to these so that happens.
