### PR TITLE
3th-party plugin: cluster-vhost

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,7 @@ cluster('./app')
    - [cluster-mail](https://github.com/LearnBoost/cluster-mail) email exception notifications
    - [cluster-exception](https://github.com/3rd-eden/cluster.exception) extensive exception notifications
    - [cluster-responsetimes](https://github.com/mnutt/cluster-responsetimes) response time statistics for cluster's REPL
+   - [cluster-vhost](https://github.com/AndreasMadsen/cluster-vhost) add virtual host support to cluster
 
 ## Screencasts
 


### PR DESCRIPTION
I have created a virtual host router plugin to cluster, there allow the user to have multiply virtual hosts domains without setting up a proxy-table manual.

I still need a lot of testing, but the example in the readme.md do work.

_This was also discussed in #157_.
