### PR TITLE
Delay workers from closing (Closes #167)

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -139,14 +139,30 @@ Worker.prototype.connect = function(id, options){
 };
 
 /**
- * Immediate shutdown.
+ * Shutdown the process (using process.nextTick to put it at the end of
+ * event queue).
+ *
+ * If the master is listening on the 'worker close' event, a callback
+ * is passed. The callback *must* be called to shutdown the worker.
  *
  * @api private
  */
 
-Worker.prototype.destroy = function(){
-  this.emit('close');
-  process.nextTick(process.exit);
+Worker.prototype.destroy = function() {
+  var eventName = 'worker close'
+    , listeners = this.master.listeners(eventName);
+
+  var exit = function() {
+    process.nextTick(process.exit());
+  };
+
+  if (listeners.length > 0) {
+    this.master.emit(eventName, function() {
+      exit();
+    });
+  } else {
+    exit();
+  }
 };
 
 /**


### PR DESCRIPTION
We need to do some db cleanup before exiting workers (same issues seen #167).

The old implementation calls process.nextTick(process.exit()) - which prevents any new code on the event queue from running _after_ the event is emitted, but _before_ process.exit() is called.

Also, it appears as though the 'close' event was never propagated up to the master.  I decided to propagate 'worker closed' instead.

Commit Message:
- emit 'worker close' in master process when a worker closes
- delay execution of process.exit with a callback when listening on 'worker close'

This closes #167
