### PR TITLE
Spawned workers should use the same working directory as the master.

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -205,7 +205,7 @@ Worker.prototype.spawn = function(id){
   this.proc = spawn(
       node
     , this.master.cmd
-    , { customFds: customFds, env: env });
+    , { customFds: customFds, env: env, cwd: process.cwd() });
 
   // unix domain socket for ICP + fd passing
   this.sock = new net.Socket(fds[1], 'unix');


### PR DESCRIPTION
Before this fix, the process.cwd() of workers was the parent directory of the running script rather than the current working directory of the master script process. This fix ensures that the workers have the same process.cwd() as the master.
